### PR TITLE
use carpentrycon twitter account

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -78,7 +78,7 @@
 
             </div>
             <div class="col-md-2 col-sm-2">
-                <a class="twitter-timeline" href="https://twitter.com/thecarpentries?ref_src=twsrc%5Etfw">Tweets by thecarpentries</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                <a class="twitter-timeline" href="https://twitter.com/{{ site.twitterAccount }}">Tweets by CarpentryCon</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
         </div>
         {% endif %}


### PR DESCRIPTION
Addresses part of #7 by using the CarpentryCon Twitter account instead of the general Carpentries account.  