### PR TITLE
Add submissions blog post and link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,8 @@ heroButtons:
 #  - {link: "https://www.eventbrite.com/e/carpentrycon-2020-tickets-88906089507", text: "Register To Attend"}
 #  - {link: "https://github.com/carpentries/conversations/issues/22", text: "Design a t-shirt"}
 #  - {link: "https://carpentries.typeform.com/to/hqoY3I", text: "Become a Sponsor"}
-- {link: "https://www.youtube.com/playlist?list=PLXLapl_LKb4fx-t_4MBSPiefTraj5KdJ8", text: "Watch Session Recordings from 2020 CarpentryCon @ Home"}
+#  - {link: "https://www.youtube.com/playlist?list=PLXLapl_LKb4fx-t_4MBSPiefTraj5KdJ8", text: "Watch Session Recordings from 2020 CarpentryCon @ Home"}
+  - {link: "https://docs.google.com/forms/d/e/1FAIpQLSfo3mOA2atW3WN7Z0NKW9sJLPuH7jtIm67RNAYoM5UCDGk53g/viewform", text: "Propose a Session!"}
 heroTheme: "Expanding Data Frontiers"
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -156,7 +156,7 @@ tweetsFeedImage: "/img/sections-background/twitter-banner.jpg"
 tweetsFeedImageCreditText: "Photo by Mish Vizesi on Unsplash"
 tweetsFeedImageImageLink: "https://www.wisc.edu/"
 tweetsFeedTitle: "What's Up?"
-twitterHashTag: "CarpentryConAtHome"
+twitterHashTag: "CarpentryCon2022"
 twitterFeed: "https://twitter.com/carpentrycon"
 
 # Partners Block

--- a/_posts/2022-03-25-welcome-carpentrycon-2022.md
+++ b/_posts/2022-03-25-welcome-carpentrycon-2022.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Welcome to the CarpentryCon 2022 Blog"
+title:  "Welcome to CarpentryCon 2022!"
 date:   2022-03-25 09:00:00
 isStaticPost: false
 tags: announcements

--- a/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
+++ b/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title:  "Keeping up with CapentryCon2022"
+title:  "Keeping up with CarpentryCon2022"
 date:   2022-04-30 09:00:00
 isStaticPost: false
 tags: announcements
 image: cc2020-pebbles.jpg
 ---
 
-CapentryCon news and updates will be circulated on various channels. Here's a quick guide on dates to save and sources to watch. 
+CarpentryCon news and updates will be circulated on various channels. Here's a quick guide on dates to save and sources to watch. 
 We're very excited for the conference, and details about proposal submission, keynote speakers, and registration will be available soon! 
 
 Stay tuned to the following channels to hear about our keynote speakers and other updates:

--- a/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
+++ b/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
@@ -12,11 +12,11 @@ We're very excited for the conference, and details about proposal submission, ke
 
 Stay tuned to the following channels to hear about our keynote speakers and other updates:
 
-- [CC@Home on Twitter](https://twitter.com/carpentrycon)
-- [CC@Home Slack](https://app.slack.com/accept-shared-channel/T0E80GCKS/I039V9V3JAU/enQtMzMzNTMzNTEyMDM2OC0xZmYyZGQ3MWU0ZjdkNGNjODU0YzQ5NWQ2MjYwYzk4Yjk1NDA2NmRlMjk5N2ZmYWY5MmZjNTU0M2NkYWQyMWUw)
-- [CC@Home Blog](https://2022.carpentrycon.org/blog/)
+- [CarpentryCon2022 on Twitter](https://twitter.com/carpentrycon)
+- [CarpentryCon2022 Slack](https://app.slack.com/accept-shared-channel/T0E80GCKS/I039V9V3JAU/enQtMzMzNTMzNTEyMDM2OC0xZmYyZGQ3MWU0ZjdkNGNjODU0YzQ5NWQ2MjYwYzk4Yjk1NDA2NmRlMjk5N2ZmYWY5MmZjNTU0M2NkYWQyMWUw)
+- [CarpentryCon2022 Blog](https://2022.carpentrycon.org/blog/)
 - [The Carpentries Newsletter](https://carpentries.org/newsletter/)
 - [#{{ site.twitterHashTag }}](https://twitter.com/search?q=%23{{ site.twitterHashTag }})
 
-Happening from **1&ndash;12 August**, CarpentryCon@Home 2022 will be filled with events which will allow participants to network, build community, and enhance their technical skills all at once.
+Happening from **1&ndash;12 August**, CarpentryCon 2022 will be filled with events which will allow participants to network, build community, and enhance their technical skills all at once.
 The 2022 CarpentryCon theme will be "Expanding Data Frontiers." More information and opportunities to contribute will be posted here on the blog and circulated via these channels in the next few months as we lead up to CarpentryCon 2022. 

--- a/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
+++ b/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title:  "Keeping up with CapentryCon2022"
+date:   2022-04-30 09:00:00
+isStaticPost: false
+tags: announcements
+image: cc2020-pebbles.jpg
+---
+
+CapentryCon news and updates will be circulated on various channels. Here's a quick guide on dates to save and sources to watch. 
+We're very excited for the conference, and details about proposal submission, keynote speakers, and registration will be available soon! 
+
+Stay tuned to the following channels to hear about our keynote speakers and other updates:
+
+- [CC@Home on Twitter](https://twitter.com/carpentrycon)
+- [CC@Home Slack](https://app.slack.com/accept-shared-channel/T0E80GCKS/I039V9V3JAU/enQtMzMzNTMzNTEyMDM2OC0xZmYyZGQ3MWU0ZjdkNGNjODU0YzQ5NWQ2MjYwYzk4Yjk1NDA2NmRlMjk5N2ZmYWY5MmZjNTU0M2NkYWQyMWUw)
+- [CC@Home Blog](https://2022.carpentrycon.org/blog/)
+- [The Carpentries Newsletter](https://carpentries.org/newsletter/)
+- [#CarpentryConatHome](https://twitter.com/search?q=%23CarpentryConAtHome)
+
+Happening from **1&ndash;12 August**, CarpentryCon@Home 2022 will be filled with events which will allow participants to network, build community, and enhance their technical skills all at once.
+The 2022 CarpentryCon theme will be "Expanding Data Frontiers." More information and opportunities to contribute will be posted here on the blog and circulated via these channels in the next few months as we lead up to CarpentryCon 2022. 

--- a/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
+++ b/_posts/2022-04-30-keeping-up-with-carpentrycon2022.md
@@ -16,7 +16,7 @@ Stay tuned to the following channels to hear about our keynote speakers and othe
 - [CC@Home Slack](https://app.slack.com/accept-shared-channel/T0E80GCKS/I039V9V3JAU/enQtMzMzNTMzNTEyMDM2OC0xZmYyZGQ3MWU0ZjdkNGNjODU0YzQ5NWQ2MjYwYzk4Yjk1NDA2NmRlMjk5N2ZmYWY5MmZjNTU0M2NkYWQyMWUw)
 - [CC@Home Blog](https://2022.carpentrycon.org/blog/)
 - [The Carpentries Newsletter](https://carpentries.org/newsletter/)
-- [#CarpentryConatHome](https://twitter.com/search?q=%23CarpentryConAtHome)
+- [#{{ site.twitterHashTag }}](https://twitter.com/search?q=%23{{ site.twitterHashTag }})
 
 Happening from **1&ndash;12 August**, CarpentryCon@Home 2022 will be filled with events which will allow participants to network, build community, and enhance their technical skills all at once.
 The 2022 CarpentryCon theme will be "Expanding Data Frontiers." More information and opportunities to contribute will be posted here on the blog and circulated via these channels in the next few months as we lead up to CarpentryCon 2022. 

--- a/_posts/2022-05-03-proposal-submission-open.md
+++ b/_posts/2022-05-03-proposal-submission-open.md
@@ -57,7 +57,7 @@ To propose a session, please use the [online submission form](https://docs.googl
 - We will start reviewing the submitted proposals as they are received.
 - Notification of accepted proposals will be sent to participants no later than **17 June**.
 - Event registration will open **1 June**; _registration will be free_.
-- See the [previous post]({% post_url 2022-04-30-keeping-up-with-carpentrycon2022 %}) for more channels to follow for CarpentryCon information.
+- See the "[Keeping Up with CarpentryCon]({% post_url 2022-04-30-keeping-up-with-carpentrycon2022 %})" post for more channels to follow for CarpentryCon information.
 - You can add this event to your calendar [here](https://calendar.google.com/event?action=TEMPLATE&tmeid=NGhyNW50YmhscXEyNnQzMGpzMnBhMGZnbW4gb3NldXVvaHQwdHZqYm9rZ2czbm9oOGM0N2dAZw&tmsrc=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com).
 
 ## Questions

--- a/_posts/2022-05-03-proposal-submission-open.md
+++ b/_posts/2022-05-03-proposal-submission-open.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title:  "CarpentryCon Proposal Submission is Now Open!"
+date:   2022-05-03 09:00:00
+isStaticPost: false
+tags: announcements
+---
+
+CarpentryCon is one of the most anticipated events of The Carpentries for community-building and networking. The theme for CarpentryCon 2022, _Expanding Data Frontiers_, will offer opportunities for the community to explore topics that will expand their knowledge and understanding of all things Carpentries. This two-week event, happening 1&ndash;12 August, brings together new and experienced community members to network, share knowledge, develop new skills, and exchange strategies for building communities of practice. The conference will be held virtually and structured to accommodate sessions across multiple time zones. Come and help develop our future leaders through practical skill-ups, networking, workshops, and breakout sessions. 
+
+We invite you to [submit proposals](https://docs.google.com/forms/d/e/1FAIpQLSfo3mOA2atW3WN7Z0NKW9sJLPuH7jtIm67RNAYoM5UCDGk53g/viewform?usp=sf_link) to share your knowledge and skills to help enhance research and learning outcomes for our community. You will also support expanding data and computational skills for librarians, scholars, scientists, and technologists from various domains. We welcome topics that align with the theme such as:
+
+- Diversity in coding
+- Women in artificial intelligence
+- State of the open source movement
+- Data care skills for equity
+- Outreach and awareness of Carpentries outside our community
+- Data and information literacy in the age of misinformation
+- Communities and FAIR
+- Data inclusivity and diversity
+- Accessible data for all
+
+Members of the community, through our Community Discussions, have also provided the following list of sessions of interest:
+
+- Encouraging success stories from workshop attendees, including specific use cases
+- Security factors while working online
+- Creative ways to organise workshops (e.g., organising funding, finding attendees)
+- The contexts in which The Carpentries are being used (e.g., academia, labs, government, private/corporate sector, secondary schools)
+- Helpful tools for teaching and examples of using them in a workshop
+- Ethical considerations for data analysis and/or sensitive data analysis (e.g., CARE Principles for Indigenous Data Governance)
+- Bias and/or encoded racism or social assumptions in programming tools 
+- How to run an effective online workshop/teach effectively online
+- Pain points in different languages and reflections on non-English-speaking workshops
+- More pedagogy, teaching about teaching
+- How to plan your workshop with diversity, equity, inclusion and accessibility in mind
+- Moving beyond Python and R to Julia, Matlab, Scala, etc.
+- How to develop content/lessons, particularly in a Team Science approach 
+- Adding high performance computing (HPC) skillsets or using cloud hosting platforms (e.g., Google Cloud, AWS, Azure) for researchers
+- Professional development content about systems change (e.g. https://www.ashoka.org/en-gb/systems-change)
+- Multiple ways and opportunities for the community to connect to strengthen intra-organizational ties
+
+## Submit a Proposal
+
+To propose a session, please use the [online submission form](https://docs.google.com/forms/d/e/1FAIpQLSfo3mOA2atW3WN7Z0NKW9sJLPuH7jtIm67RNAYoM5UCDGk53g/viewform?usp=sf_link). As an international community, we welcome sessions in languages other than English. On the form, you can also indicate which time zones you will be able to lead your session and if you would be willing to lead your session more than once. #{{ site.twitterHashTag }} will have six types of sessions: 
+
+- **Breakout discussions** will be 1.5 hour-long and conducted in a round table or general discussion format. These discussions will play a crucial role in connecting participants based on shared interests and stimulate discussion on relevant topics. 
+- **Lesson and resource development sprints** will be one-day to two-week-long collaborative efforts to co-develop lessons and resources relevant to the community. Opportunities will be provided to contribute synchronously and asynchronously to these sprints.
+- **Lightning talks** will be short, 5-minute presentations to share tips with the community (e.g., techniques to improve research and teaching, growing a local Carpentries community). These will be pre-recorded so that subtitles in multiple languages can be added and to accommodate asynchronous viewing. There will also be a time in the program dedicated to synchronous viewing and Q&A with the presenters.  
+- **Panel sessions** will be 1-1.5 hour-long live discussions about a specific topic amongst a selected group of panellists who share differing perspectives. The proposal author or suggested lead will moderate and guide the panel and audience through the event. Panellists are ideally 3-4 experts in the field who will share ideas, evidence/studies, and opinions and address questions from the audience.
+- **Skill-up workshops** will be 1.5-2 hour-long sessions that provide professional development opportunities where community members share their expertise. 
+- **Social events and informal meetups** will be 1-2 hour-long sessions that allow attendees to network with other community members. As determined by each session host, these sessions will range from informal discussions to playing games to virtual storytelling. We encourage creativity!
+
+## Important Information
+
+- Last date for proposal submissions will be **12 June**.
+- We will start reviewing the submitted proposals as they are received.
+- Notification of accepted proposals will be sent to participants no later than **17 June**.
+- Event registration will open **1 June**; _registration will be free_.
+- See the [previous post]({% post_url 2022-04-30-keeping-up-with-carpentrycon2022 %}) for more channels to follow for CarpentryCon information.
+- You can add this event to your calendar [here](https://calendar.google.com/event?action=TEMPLATE&tmeid=NGhyNW50YmhscXEyNnQzMGpzMnBhMGZnbW4gb3NldXVvaHQwdHZqYm9rZ2czbm9oOGM0N2dAZw&tmsrc=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com).
+
+## Questions
+
+If you need any support completing the proposal submission form, would like to view the form in another language, or have any questions, please email [carpentrycon@carpentries.org](mailto:carpentrycon@carpentries.org).

--- a/_posts/2022-05-03-proposal-submission-open.md
+++ b/_posts/2022-05-03-proposal-submission-open.md
@@ -3,6 +3,7 @@ layout: post
 title:  "CarpentryCon Proposal Submission is Now Open!"
 date:   2022-05-03 09:00:00
 isStaticPost: false
+image: cc2020-network.jpg
 tags: announcements
 ---
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ permalink: /
 
  {% include hero.html %}
  
- <!-- include blog.html has been removed until more 2022 blog posts are up. -->
+ {% include blog.html %}
  
  {% include twitter-feed.html %}
 


### PR DESCRIPTION
This pull request contains:  
- update to the front page to display blog posts 
- adds two new blog posts (including the opening of submissions post)
- adds the button for inviting submissions to the front page
- updates hashtag to CarpentryCon2022