### PR TITLE
Update event title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME', 'vendor']
 sass: compact
 
 # Site Settings
-title: "CarpentryCon @ Home"
+title: "CarpentryCon 2022"
 email: "carpentrycon@carpentries.org"
 description: "Biennial community conference for The Carpentries global community, online in 2022"
 baseurl: ""
@@ -61,7 +61,7 @@ rightNavigationButtons:
 
 # Hero Block
 heroImage: "cc2018.jpg"
-heroTitle: "CarpentryCon @ Home"
+heroTitle: "CarpentryCon 2022"
 heroSubTitle: ""
 eventDate: "August 1-12, 2022"
 #typeoutTextValues: '""'

--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,7 @@ rightNavigationButtons:
 # Hero Block
 heroImage: "cc2018.jpg"
 heroTitle: "CarpentryCon 2022"
-heroSubTitle: ""
+heroSubTitle: "Submit proposals by 12 June!"
 eventDate: "August 1-12, 2022"
 #typeoutTextValues: '""'
 #typeoutFallback: ""

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -2,7 +2,9 @@
 <section id="schedule" class="schedule">
     <div class="content-wrapper">
 
-        <h5>Check back for our schedule for CarpentryCon 2022!</h5>
+        <h5>We plan to post the schedule after June 17 ...</h5>
+        <h5>Check back soon!</h5>
+        <hr />
         <h5>In the meantime, you can <a href="{{ site.url2020 }}/schedule">revisit the schedule from CarpentryCon 2020</a>.</h5>
 
 </div>

--- a/schedule.html
+++ b/schedule.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: CarpentryCon @ Home Schedule
+title: CarpentryCon 2022 Schedule
 permalink: /schedule/
 color: "#065479"
 ---


### PR DESCRIPTION
Adding changes to event title, to CarpentryCon 2022 per discussions with comms committee.